### PR TITLE
Work around constant upstream issues pulling gpg keys

### DIFF
--- a/resources/osl_virtualbox.rb
+++ b/resources/osl_virtualbox.rb
@@ -17,6 +17,8 @@ action :install do
   apt_repository 'virtualbox' do
     components %w(contrib)
     uri 'https://download.virtualbox.org/virtualbox/debian'
+    # Work around constant upstream issues pulling gpg keys
+    ignore_failure true
     key %w(
       https://www.virtualbox.org/download/oracle_vbox_2016.asc
       https://www.virtualbox.org/download/oracle_vbox.asc

--- a/spec/unit/resources/osl_virtualbox.rb
+++ b/spec/unit/resources/osl_virtualbox.rb
@@ -39,6 +39,7 @@ describe 'osl_packagecloud_repo' do
       is_expected.to add_apt_repository('virtualbox')
         .with(
           uri: 'https://download.virtualbox.org/virtualbox/debian',
+          ignore_failure: true,
           key: %w(
             https://www.virtualbox.org/download/oracle_vbox_2016.asc
             https://www.virtualbox.org/download/oracle_vbox.asc


### PR DESCRIPTION
They seem to have issues with their http servers hosting the keys often and break chef runs on workstations constantly. We should just skip it and not fail the whole run.

Signed-off-by: Lance Albertson <lance@osuosl.org>
