### PR TITLE
Use a short checksum of the key name for resource names

### DIFF
--- a/resources/osl_authorized_keys.rb
+++ b/resources/osl_authorized_keys.rb
@@ -17,7 +17,7 @@ action :add do
     recursive true
   end
 
-  line_append_if_no_line "#{new_resource.user}-#{new_resource.key}" do
+  line_append_if_no_line "#{new_resource.user}-#{key_sha}" do
     path "#{new_resource.dir_path}/authorized_keys"
     line new_resource.key
     owner new_resource.user
@@ -27,7 +27,7 @@ action :add do
 end
 
 action :remove do
-  line_delete_lines "#{new_resource.user}-#{new_resource.key}" do
+  line_delete_lines "#{new_resource.user}-#{key_sha}" do
     path "#{new_resource.dir_path}/authorized_keys"
     pattern "^#{new_resource.key}$"
   end
@@ -40,5 +40,15 @@ action :remove do
   directory new_resource.dir_path do
     action :delete
     only_if { ::Dir.empty?(new_resource.dir_path) }
+  end
+end
+
+action_class do
+  require 'digest/sha1'
+
+  private
+
+  def key_sha
+    Digest::SHA1.hexdigest(new_resource.key)[0, 8]
   end
 end

--- a/spec/unit/resources/osl_authorized_keys_spec.rb
+++ b/spec/unit/resources/osl_authorized_keys_spec.rb
@@ -11,6 +11,22 @@ describe 'osl_authorized_keys' do
     allow(File).to receive(:empty?).with('/home/test_user_3/.ssh/authorized_keys').and_return(false)
   end
 
+  keys =
+    [
+      {
+        'name' => 'key_1',
+        'sum' => '6866ef97',
+      },
+      {
+        'name' => 'key_2',
+        'sum' => '1388ac75',
+      },
+      {
+        'name' => 'key_3',
+        'sum' => '07ef8d13',
+      },
+    ]
+
   recipe do
     %w(key_1 key_2 key_3).each do |k|
       osl_authorized_keys k do
@@ -40,27 +56,31 @@ describe 'osl_authorized_keys' do
       group: 'test_user_1'
     )
   end
-  it do
-    %w(key_1 key_2 key_3).each do |k|
-      is_expected.to edit_line_append_if_no_line("test_user_1-#{k}").with(
+
+  keys.each do |k|
+    it do
+      is_expected.to edit_line_append_if_no_line("test_user_1-#{k['sum']}").with(
         path: '/home/test_user_1/.ssh/authorized_keys',
-        line: k,
+        line: k['name'],
         owner: 'test_user_1',
         group: 'test_user_1'
       )
     end
   end
-  it do
-    %w(key_1 key_2 key_3).each do |k|
-      is_expected.to edit_line_delete_lines("test_user_1-#{k}").with(
+
+  keys.each do |k|
+    it do
+      is_expected.to edit_line_delete_lines("test_user_1-#{k['sum']}").with(
         path: '/home/test_user_1/.ssh/authorized_keys',
-        pattern: "^#{k}$"
+        pattern: "^#{k['name']}$"
       )
     end
   end
+
   it do
     is_expected.to delete_directory('/home/test_user_1/.ssh')
   end
+
   it do
     is_expected.to delete_file('/home/test_user_1/.ssh/authorized_keys')
   end
@@ -72,11 +92,12 @@ describe 'osl_authorized_keys' do
       group: 'nobody'
     )
   end
-  it do
-    %w(key_1 key_2 key_3).each do |k|
-      is_expected.to edit_line_append_if_no_line("test_user_2-#{k}").with(
+
+  keys.each do |k|
+    it do
+      is_expected.to edit_line_append_if_no_line("test_user_2-#{k['sum']}").with(
         path: '/opt/test/.ssh/authorized_keys',
-        line: k,
+        line: k['name'],
         owner: 'test_user_2',
         group: 'nobody'
       )
@@ -84,16 +105,16 @@ describe 'osl_authorized_keys' do
   end
 
   it do
-    %w(key_2).each do |k|
-      is_expected.to edit_line_delete_lines("test_user_3-#{k}").with(
-        path: '/home/test_user_3/.ssh/authorized_keys',
-        pattern: "^#{k}$"
-      )
-    end
+    is_expected.to edit_line_delete_lines('test_user_3-1388ac75').with(
+      path: '/home/test_user_3/.ssh/authorized_keys',
+      pattern: '^key_2$'
+    )
   end
+
   it do
     is_expected.to_not delete_directory('/home/test_user_3/.ssh')
   end
+
   it do
     is_expected.to_not delete_file('/home/test_user_3/.ssh/authorized_keys')
   end


### PR DESCRIPTION
We shouldn't include the whole public ssh key in the chef output, so instead let's just use the short SHA1 of the name so it's at least unique.

Signed-off-by: Lance Albertson <lance@osuosl.org>
