### PR TITLE
Migrate osl_local_ipv4? and osl_local_ipv6? methods from base cookbook

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,6 +1,9 @@
 module OSLResources
   module Cookbook
     module Helpers
+      require 'ipaddr'
+      require 'iniparse'
+
       # osl_ifconfig helpers
       def default_nm_controlled
         node['platform_version'].to_i >= 8 ? 'yes' : 'no'
@@ -8,7 +11,6 @@ module OSLResources
 
       # Based on https://github.com/chef/chef/blob/61a8aa44ac33fc3bbeb21fa33acf919a97272eb7/lib/chef/resource/systemd_unit.rb#L66-L83
       def to_ini(content)
-        require 'iniparse'
         case content
         when Hash
           IniParse.gen do |doc|
@@ -50,8 +52,58 @@ module OSLResources
           ]
         end
       end
+
+      def osl_local_ipv4?
+        local = false
+        ip = IPAddr.new(node['ipaddress'])
+        osl_local_ip.each do |net|
+          net = IPAddr.new net
+          local = net.include?(ip)
+          break if local
+        end
+        local
+      end
+
+      def osl_local_ipv6?
+        # If we don't have an IPv6, let's just assume it's false
+        return false unless node['ip6address']
+
+        local = false
+        ip = IPAddr.new(node['ip6address'])
+        osl_local_ip.each do |net|
+          net = IPAddr.new net
+          local = net.include?(ip)
+          break if local
+        end
+        local
+      end
+
+      private
+
+      def osl_local_ip
+        # These are local to the OSU campus
+        [
+          '10.0.0.0/23',
+          '10.1.0.0/23',
+          '10.1.2.0/23',
+          '10.1.100.0/22',
+          '10.6.4.0/22',
+          '10.162.136.0/24',    # Milne Workstation subnet
+          '128.193.126.192/28', # Milne Server subnet
+          '128.193.152.128/27', # OSU Gateway from Milne workstations
+          '140.211.9.0/24',
+          '140.211.10.0/24',
+          '140.211.15.0/24',
+          '140.211.166.0/23',
+          '140.211.168.0/24',
+          '140.211.169.0/24',
+          '2605:bc80:3010::/48',
+        ]
+      end
     end
   end
 end
 Chef::DSL::Recipe.include ::OSLResources::Cookbook::Helpers
 Chef::Resource.include ::OSLResources::Cookbook::Helpers
+# Needed to used in attributes/
+Chef::Node.include ::OSLResources::Cookbook::Helpers

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+require_relative '../../../libraries/helpers'
+
+RSpec.describe OSLResources::Cookbook::Helpers do
+  class DummyClass < Chef::Node
+    include OSLResources::Cookbook::Helpers
+  end
+
+  subject { DummyClass.new }
+
+  describe '#osl_local_ipv4?' do
+    it 'local IPv4 address' do
+      allow(subject).to receive(:[]).with('ipaddress').and_return('140.211.166.130')
+      expect(subject.osl_local_ipv4?).to eq true
+    end
+    it 'external IPv4 address' do
+      allow(subject).to receive(:[]).with('ipaddress').and_return('216.165.191.54')
+      expect(subject.osl_local_ipv4?).to eq false
+    end
+  end
+
+  describe '#osl_local_ipv6?' do
+    it 'local IPv6 address' do
+      allow(subject).to receive(:[]).with('ip6address').and_return('2605:bc80:3010::130')
+      expect(subject.osl_local_ipv6?).to eq true
+    end
+    it 'external IPv6 address' do
+      allow(subject).to receive(:[]).with('ip6address').and_return('2600:3402:600:24::154')
+      expect(subject.osl_local_ipv6?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
This untethers it from the base cookbook and helps clean up the cookbook dependencies.

Signed-off-by: Lance Albertson <lance@osuosl.org>
