### PR TITLE
Create osl_python resource

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -46,6 +46,9 @@ suites:
   - name: osl_packagecloud_repo
     run_list:
       - recipe[osl-resources-test::osl_packagecloud_repo]
+  - name: osl_python
+    run_list:
+      - recipe[osl-resources-test::osl_python]
   - name: osl_route
     excludes:
       - debian-11

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -78,6 +78,56 @@ module OSLResources
         local
       end
 
+      def osl_python_packages
+        case node['platform_family']
+        when 'rhel'
+          case node['platform_version'].to_i
+          when 8
+            %w(
+              python2
+              python2-devel
+              python2-pip
+              python2-setuptools
+              python2-virtualenv
+              python3-pip
+              python3-setuptools
+              python3-virtualenv
+              python36
+              python36-devel
+            )
+          when 7
+            %w(
+              python
+              python2-pip
+              python3
+              python3-devel
+              python3-pip
+              python3-setuptools
+              python-devel
+              python-setuptools
+              python-virtualenv
+            )
+          end
+        when 'debian'
+          case node['platform_version'].to_i
+          when 11
+            %w(
+              python3
+              python3-dev
+              python3-pip
+              python3-setuptools
+              python3-virtualenv
+              python3-wheel
+              python2-dev
+              python-pip-whl
+              python-setuptools
+              virtualenv
+              python-wheel-common
+            )
+          end
+        end
+      end
+
       private
 
       def osl_local_ip

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ description      'Holds base resources for the OSUOSL'
 version          '1.3.1'
 
 depends          'line'
+depends          'osl-repos'
 
 supports         'centos', '~> 7.0'
 supports         'centos_stream', '~> 8.0'

--- a/resources/osl_python.rb
+++ b/resources/osl_python.rb
@@ -1,0 +1,33 @@
+resource_name :osl_python
+provides :osl_python
+unified_mode true
+
+default_action :install
+
+action :install do
+  if platform_family?('rhel') && node['platform_version'].to_i < 8
+    include_recipe 'osl-repos::epel'
+  end
+
+  package 'install python packages' do
+    package_name osl_python_packages
+  end
+
+  # Debian 11 does not ship with pip2
+  if platform_family?('debian')
+    get_pip = ::File.join(Chef::Config[:file_cache_path], 'get-pip.py')
+
+    remote_file get_pip do
+      source 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
+      not_if { ::File.exist?('/usr/local/bin/pip2') }
+    end
+
+    execute "python2 #{get_pip}" do
+      creates '/usr/local/bin/pip2'
+    end
+
+    link '/usr/bin/pip2' do
+      to '/usr/local/bin/pip2'
+    end
+  end
+end

--- a/test/fixtures/cookbooks/osl-resources-test/recipes/osl_python.rb
+++ b/test/fixtures/cookbooks/osl-resources-test/recipes/osl_python.rb
@@ -1,0 +1,1 @@
+osl_python 'default'

--- a/test/integration/osl_python/controls/python_control.rb
+++ b/test/integration/osl_python/controls/python_control.rb
@@ -1,0 +1,60 @@
+control 'osl_python' do
+  title 'Verify python is configured'
+
+  os_family = os.family
+  os_release = os.release.to_i
+
+  case os_family
+  when 'redhat'
+    case os_release
+    when 8
+      packages = %w(
+        python2
+        python2-devel
+        python2-pip
+        python2-setuptools
+        python2-virtualenv
+        python3-pip
+        python3-setuptools
+        python3-virtualenv
+        python36
+        python36-devel
+      )
+    when 7
+      packages = %w(
+        python
+        python2-pip
+        python3
+        python3-devel
+        python3-pip
+        python3-setuptools
+        python-devel
+        python-setuptools
+        python-virtualenv
+      )
+    end
+  when 'debian'
+    case os_release
+    when 11
+      packages = %w(
+        python3
+        python3-dev
+        python3-pip
+        python3-setuptools
+        python3-virtualenv
+        python3-wheel
+        python2-dev
+        python-pip-whl
+        python-setuptools
+        virtualenv
+        python-wheel-common
+      )
+    end
+  end
+
+  packages.each do |pkg|
+    describe package pkg do
+      it { should be_installed }
+    end
+  end
+end

--- a/test/integration/osl_python/inspec.yml
+++ b/test/integration/osl_python/inspec.yml
@@ -1,0 +1,2 @@
+---
+name: osl_python


### PR DESCRIPTION
This migrates and replaces what used to be in base::python.

Signed-off-by: Lance Albertson <lance@osuosl.org>
