### PR TITLE
Fix gpgkey used in yum repository for virtualbox

### DIFF
--- a/resources/osl_virtualbox.rb
+++ b/resources/osl_virtualbox.rb
@@ -8,10 +8,14 @@ property :version, String, name_property: true
 
 action :install do
   yum_repository 'virtualbox' do
+    description "VirtualBox - #{new_resource.version}"
     baseurl 'http://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch'
     gpgcheck true
     repo_gpgcheck true
-    gpgkey 'https://www.virtualbox.org/download/oracle_vbox.asc'
+    gpgkey %w(
+      https://www.virtualbox.org/download/oracle_vbox_2016.asc
+      https://www.virtualbox.org/download/oracle_vbox.asc
+    )
   end if platform_family?('rhel')
 
   apt_repository 'virtualbox' do

--- a/spec/unit/resources/osl_virtualbox.rb
+++ b/spec/unit/resources/osl_virtualbox.rb
@@ -13,10 +13,14 @@ describe 'osl_virtualbox' do
     it do
       is_expected.to create_yum_repository('virtualbox')
         .with(
+          description: 'VirtualBox - 6.1',
           baseurl: 'http://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch',
           repo_gpgcheck: true,
           gpgcheck: true,
-          gpgkey: 'https://www.virtualbox.org/download/oracle_vbox.asc'
+          gpgkey: %w(
+            https://www.virtualbox.org/download/oracle_vbox_2016.asc
+            https://www.virtualbox.org/download/oracle_vbox.asc
+          )
         )
     end
     it { is_expected.to unload_kernel_module('kvm_amd') }


### PR DESCRIPTION
It appears that upstream has stopped using the older key and is now using the 2016 key for rpms. Let's add this plus give this repo a proper description.

Signed-off-by: Lance Albertson <lance@osuosl.org>
