### PR TITLE
osl_conntrackd resource

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -24,6 +24,11 @@ suites:
   - name: osl_awstats_site
     run_list:
       - recipe[osl-resources-test::osl_awstats_site]
+  - name: osl_conntrackd
+    run_list:
+      - recipe[osl-resources-test::osl_conntrackd]
+    excludes:
+      - debian-11
   - name: osl_dnsdist
     run_list:
       - recipe[osl-resources-test::osl_dnsdist]

--- a/resources/osl_conntrackd.rb
+++ b/resources/osl_conntrackd.rb
@@ -1,0 +1,42 @@
+resource_name :osl_conntrackd
+provides :osl_conntrackd
+unified_mode true
+
+default_action :install
+
+property :interface, String, required: true
+property :ipv4_address, String, name_property: true
+property :ipv4_destination_address, String, required: true
+property :address_ignore, Array, default: %w(127.0.0.1)
+
+action :install do
+  package 'conntrack-tools'
+
+  template '/etc/conntrackd/conntrackd.conf' do
+    source 'conntrackd.conf.erb'
+    cookbook 'osl-resources'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables(
+      interface: new_resource.interface,
+      ipv4_address: new_resource.ipv4_address,
+      ipv4_destination_address: new_resource.ipv4_destination_address,
+      address_ignore: new_resource.address_ignore
+    )
+    notifies :restart, 'service[conntrackd]'
+  end
+
+  remote_file '/etc/conntrackd/primary-backup.sh' do
+    if node['platform_version'].to_i >= 8
+      source 'file:///usr/share/doc/conntrack-tools/doc/sync/primary-backup.sh'
+    else
+      source 'file:///usr/share/doc/conntrack-tools-1.4.4/doc/sync/primary-backup.sh'
+    end
+    mode '0755'
+  end
+
+  service 'conntrackd' do
+    action [:enable, :start]
+  end
+end

--- a/spec/unit/resources/osl_conntrackd_spec.rb
+++ b/spec/unit/resources/osl_conntrackd_spec.rb
@@ -1,0 +1,63 @@
+require_relative '../../spec_helper'
+
+describe 'osl_conntrackd' do
+  platform 'almalinux', '8'
+  cached(:subject) { chef_run }
+  step_into :osl_conntrackd
+
+  recipe do
+    osl_conntrackd '192.168.0.2' do
+      interface 'eth0'
+      ipv4_destination_address '192.168.0.3'
+      address_ignore %w(127.0.0.1 192.168.0.1 192.168.0.2 192.168.0.3)
+    end
+  end
+
+  it { is_expected.to install_package 'conntrack-tools' }
+
+  it do
+    is_expected.to create_template('/etc/conntrackd/conntrackd.conf').with(
+      source: 'conntrackd.conf.erb',
+      cookbook: 'osl-resources',
+      owner: 'root',
+      group: 'root',
+      mode: '0644',
+      variables: {
+        interface: 'eth0',
+        ipv4_address: '192.168.0.2',
+        ipv4_destination_address: '192.168.0.3',
+        address_ignore: %w(127.0.0.1 192.168.0.1 192.168.0.2 192.168.0.3),
+      }
+    )
+  end
+
+  it do
+    is_expected.to create_remote_file('/etc/conntrackd/primary-backup.sh').with(
+      source: 'file:///usr/share/doc/conntrack-tools/doc/sync/primary-backup.sh',
+      mode: '0755'
+    )
+  end
+
+  it { is_expected.to enable_service('conntrackd') }
+  it { is_expected.to start_service('conntrackd') }
+
+  context 'centos 7' do
+    platform 'centos', '7'
+    cached(:subject) { chef_run }
+    step_into :osl_conntrackd
+
+    recipe do
+      osl_conntrackd '192.168.0.2' do
+        interface 'eth0'
+        ipv4_destination_address '192.168.0.3'
+        address_ignore %w(127.0.0.1 192.168.0.1 192.168.0.2 192.168.0.3)
+      end
+    end
+    it do
+      is_expected.to create_remote_file('/etc/conntrackd/primary-backup.sh').with(
+        source: 'file:///usr/share/doc/conntrack-tools-1.4.4/doc/sync/primary-backup.sh',
+        mode: '0755'
+      )
+    end
+  end
+end

--- a/templates/default/conntrackd.conf.erb
+++ b/templates/default/conntrackd.conf.erb
@@ -1,0 +1,58 @@
+Sync {
+  Mode FTFW {
+    ResendQueueSize 131072
+    CommitTimeout 180
+    PurgeTimeout 5
+    ACKWindowSize 300
+    DisableExternalCache Off
+  }
+
+  UDP {
+    IPv4_address <%= @ipv4_address %>
+    IPv4_Destination_Address <%= @ipv4_destination_address %>
+    Port 3780
+    Interface <%= @interface %>
+    SndSocketBuffer 1249280
+    RcvSocketBuffer 1249280
+    Checksum on
+  }
+}
+
+General {
+  <% if node['platform_version'].to_i >= 8 -%>
+  Systemd on
+  <% end -%>
+  Nice -20
+  HashSize 32768
+  HashLimit 131072
+  LogFile on
+  Syslog on
+  NetlinkOverrunResync 5
+  NetlinkEventsReliable on
+  PollSecs 5
+  EventIterationLimit 200
+  LockFile /var/lock/conntrack.lock
+
+  UNIX {
+    Path /var/run/conntrackd.ctl
+    Backlog 20
+  }
+
+  NetlinkBufferSize 2097152
+  NetlinkBufferSizeMaxGrowth 8388608
+
+  Filter From Userspace {
+    Protocol Accept {
+      TCP
+      UDP
+      ICMP
+      IPv6-ICMP
+    }
+
+    Address Ignore {
+      <% @address_ignore.each do |ip| -%>
+      IPv4_address <%= ip %>
+      <% end -%>
+    }
+  }
+}

--- a/test/fixtures/cookbooks/osl-resources-test/recipes/osl_conntrackd.rb
+++ b/test/fixtures/cookbooks/osl-resources-test/recipes/osl_conntrackd.rb
@@ -1,0 +1,8 @@
+osl_conntrackd node['ipaddress'] do
+  interface node['network']['default_interface']
+  ipv4_destination_address '127.0.0.1'
+  address_ignore [
+    '127.0.0.1',
+    node['ipaddress'],
+  ]
+end

--- a/test/integration/osl_conntrackd/controls/osl_conntrackd.rb
+++ b/test/integration/osl_conntrackd/controls/osl_conntrackd.rb
@@ -1,0 +1,26 @@
+ip_address = inspec.interfaces.ipv4_address
+interface = inspec.interfaces.names.first
+
+control 'osl_conntrackd' do
+  describe package 'conntrack-tools' do
+    it { should be_installed }
+  end
+
+  describe file '/etc/conntrackd/conntrackd.conf' do
+    its('content') { should match /Interface #{interface}/ }
+    its('content') { should match /IPv4_Destination_Address 127.0.0.1/ }
+    its('content') { should match /^    IPv4_address #{ip_address}/ }
+    its('content') { should match /^      IPv4_address #{ip_address}/ }
+    its('content') { should match /^      IPv4_address 127.0.0.1/ }
+  end
+
+  describe file '/etc/conntrackd/primary-backup.sh' do
+    it { should be_executable }
+    it { should exist }
+  end
+
+  describe service 'conntrackd' do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/test/integration/osl_conntrackd/inspec.yml
+++ b/test/integration/osl_conntrackd/inspec.yml
@@ -1,0 +1,1 @@
+name: osl_conntrackd


### PR DESCRIPTION
This resource is used for setting up the conntrackd daemon. This is useful for NAT gateway systems configured in an HA setup.

Signed-off-by: Lance Albertson <lance@osuosl.org>
