### PR TITLE
Allow key to be an array in osl_authorized_keys

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,6 +18,9 @@ suites:
   - name: osl_authorized_keys_remove
     run_list:
       - recipe[osl-resources-test::osl_authorized_keys_remove]
+    provisioner:
+      enforce_idempotency: false
+      multiple_converge: 1
   - name: osl_awstats_site
     run_list:
       - recipe[osl-resources-test::osl_awstats_site]

--- a/spec/unit/resources/osl_authorized_keys_spec.rb
+++ b/spec/unit/resources/osl_authorized_keys_spec.rb
@@ -35,12 +35,11 @@ describe 'osl_authorized_keys' do
       end
     end
 
-    %w(key_1 key_2 key_3).each do |k|
-      osl_authorized_keys k do
-        user 'test_user_2'
-        group 'nobody'
-        dir_path '/opt/test/.ssh'
-      end
+    osl_authorized_keys 'test_user_2' do
+      key %w(key_1 key_2 key_3)
+      user 'test_user_2'
+      group 'nobody'
+      dir_path '/opt/test/.ssh'
     end
 
     osl_authorized_keys 'key_2' do

--- a/test/fixtures/cookbooks/osl-resources-test/recipes/osl_authorized_keys.rb
+++ b/test/fixtures/cookbooks/osl-resources-test/recipes/osl_authorized_keys.rb
@@ -5,10 +5,10 @@ user 'test_user'
     user 'test_user'
   end
 end
-%w(key_1 key_2 key_3).each do |k|
-  osl_authorized_keys k do
-    user 'test_user'
-    group 'root'
-    dir_path '/opt/test/.ssh'
-  end
+
+osl_authorized_keys 'test_user' do
+  key %w(key_1 key_2 key_3)
+  user 'test_user'
+  group 'root'
+  dir_path '/opt/test/.ssh'
 end

--- a/test/fixtures/cookbooks/osl-resources-test/recipes/osl_authorized_keys_remove.rb
+++ b/test/fixtures/cookbooks/osl-resources-test/recipes/osl_authorized_keys_remove.rb
@@ -1,10 +1,9 @@
 user 'test_user_1'
 user 'test_user_2'
 
-%w(key_1 key_2 key_3).each do |k|
-  osl_authorized_keys k do
-    user 'test_user_1'
-  end
+osl_authorized_keys 'test_user_1' do
+  key %w(key_1 key_2 key_3)
+  user 'test_user_1'
 end
 
 osl_authorized_keys 'key_2' do
@@ -19,6 +18,7 @@ directory '/home/test_user_2/.ssh' do
   recursive true
   action :create
 end
+
 file '/home/test_user_2/.ssh/id_rsa' do
   content 'test_key'
   owner 'test_user_2'
@@ -26,9 +26,8 @@ file '/home/test_user_2/.ssh/id_rsa' do
   mode '0600'
 end
 
-%w(key_1 key_2).each do |k|
-  osl_authorized_keys k do
-    user 'test_user_2'
-    action [:add, :remove]
-  end
+osl_authorized_keys 'test_user_2' do
+  key %w(key_1 key_2)
+  user 'test_user_2'
+  action [:add, :remove]
 end


### PR DESCRIPTION
Coerce the property into an array to make it easier to manage.

Signed-off-by: Lance Albertson <lance@osuosl.org>
