### PR TITLE
Add osl_pagefind resource

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -149,6 +149,9 @@ suites:
   - name: osl_hugo
     run_list:
       - recipe[osl-resources-test::osl_hugo]
+  - name: osl_pagefind
+    run_list:
+      - recipe[osl-resources-test::osl_pagefind]
   - name: osl_udev_rules
     run_list:
       - recipe[osl-resources-test::osl_udev_rules]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -108,9 +108,9 @@ module OSLResources
       private
 
       # Get latest version of hugo from Github
-      def osl_hugo_latest_version(version)
+      def osl_github_latest_version(repo, version)
         releases = []
-        uri = URI('https://api.github.com/repos/gohugoio/hugo/releases')
+        uri = URI("https://api.github.com/repos/#{repo}/releases")
         response = JSON.parse(Net::HTTP.get(uri))
         response.each do |rel|
           # Match version given

--- a/resources/osl_hugo.rb
+++ b/resources/osl_hugo.rb
@@ -9,7 +9,7 @@ property :version, String, default: '0'
 action :install do
   package 'tar'
 
-  hugo_version = osl_hugo_latest_version(new_resource.version)
+  hugo_version = osl_github_latest_version('gohugoio/hugo', new_resource.version)
 
   ark 'hugo' do
     url "https://github.com/gohugoio/hugo/releases/download/v#{hugo_version}/hugo_#{hugo_version}_Linux-64bit.tar.gz"

--- a/resources/osl_pagefind.rb
+++ b/resources/osl_pagefind.rb
@@ -1,0 +1,22 @@
+resource_name :osl_pagefind
+provides :osl_pagefind
+unified_mode true
+
+default_action :install
+
+property :version, String, default: '1'
+
+action :install do
+  package 'tar'
+
+  pagefind_version = osl_github_latest_version('cloudcannon/pagefind', new_resource.version)
+
+  ark 'pagefind' do
+    url "https://github.com/CloudCannon/pagefind/releases/download/v#{pagefind_version}/pagefind-v#{pagefind_version}-x86_64-unknown-linux-musl.tar.gz"
+    prefix_root '/opt'
+    prefix_home '/opt'
+    has_binaries %w(pagefind)
+    strip_components 0
+    version pagefind_version
+  end
+end

--- a/spec/unit/resources/osl_pagefind.rb
+++ b/spec/unit/resources/osl_pagefind.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'osl_pagefind' do
+  recipe do
+    osl_pagefind 'default'
+  end
+
+  context 'almalinux' do
+    platform 'almalinux'
+    cached(:subject) { chef_run }
+    step_into :osl_pagefind
+
+    github_releases = [{ name: 'v1.1.1' }, { name: 'v1.1.0' }, { name: 'v1.0.0' }]
+
+    before do
+      allow(Net::HTTP).to receive(:get).and_return(github_releases.to_json)
+    end
+
+    it { is_expected.to install_package 'tar' }
+    it do
+      is_expected.to install_ark('pagefind').with(
+        url: 'https://github.com/CloudCannon/pagefind/releases/download/v1.1.1/pagefind-v1.1.1-x86_64-unknown-linux-musl.tar.gz',
+        prefix_root: '/opt',
+        prefix_home: '/opt',
+        has_binaries: %w(pagefind),
+        strip_components: 0,
+        version: '1.1.1'
+      )
+    end
+  end
+end

--- a/test/fixtures/cookbooks/osl-resources-test/recipes/osl_pagefind.rb
+++ b/test/fixtures/cookbooks/osl-resources-test/recipes/osl_pagefind.rb
@@ -1,0 +1,1 @@
+osl_pagefind 'default'

--- a/test/integration/osl_pagefind/controls/osl_pagefind.rb
+++ b/test/integration/osl_pagefind/controls/osl_pagefind.rb
@@ -1,0 +1,15 @@
+control 'osl_pagefind' do
+  describe file('/opt/pagefind/pagefind') do
+    it { should exist }
+    its('size') { should be > 0 }
+  end
+  describe file('/usr/local/bin/pagefind') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('link_path') { should match %r{/opt/pagefind-1.+/pagefind} }
+  end
+  describe command '/usr/local/bin/pagefind -V' do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match /^pagefind 1.+/ }
+  end
+end

--- a/test/integration/osl_pagefind/inspec.yml
+++ b/test/integration/osl_pagefind/inspec.yml
@@ -1,0 +1,1 @@
+name: osl_pagefind


### PR DESCRIPTION
This installs pagefind [1] which is needed on our Hugo based website.

Also rename the library help to make it reusable for other github releases.

[1] https://pagefind.app/

Signed-off-by: Lance Albertson <lance@osuosl.org>
