### PR TITLE
osl_hugo: Add rescue block around ark resource

### DIFF
--- a/resources/osl_hugo.rb
+++ b/resources/osl_hugo.rb
@@ -11,12 +11,16 @@ action :install do
 
   hugo_version = osl_github_latest_version('gohugoio/hugo', new_resource.version)
 
-  ark 'hugo' do
-    url "https://github.com/gohugoio/hugo/releases/download/v#{hugo_version}/hugo_#{hugo_version}_Linux-64bit.tar.gz"
-    prefix_root '/opt'
-    prefix_home '/opt'
-    has_binaries %w(hugo)
-    strip_components 0
-    version hugo_version
+  begin
+    ark 'hugo' do
+      url "https://github.com/gohugoio/hugo/releases/download/v#{hugo_version}/hugo_#{hugo_version}_Linux-64bit.tar.gz"
+      prefix_root '/opt'
+      prefix_home '/opt'
+      has_binaries %w(hugo)
+      strip_components 0
+      version hugo_version
+    end
+  rescue
+    Chef::Log.warn("Error downloading hugo-#{hugo_version}, skipping for now")
   end
 end


### PR DESCRIPTION
Apparently upstream did a release that didn't contain any binaries. So let's
work around this for now.

Signed-off-by: Lance Albertson <lance@osuosl.org>
