### PR TITLE
Move osl_github_latest_version helper method as public method

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -124,9 +124,7 @@ module OSLResources
         output.join("\n")
       end
 
-      private
-
-      # Get latest version of hugo from Github
+      # Get latest version of repo release from Github
       def osl_github_latest_version(repo, version, key = 'name')
         releases = []
         uri = URI("https://api.github.com/repos/#{repo}/releases")
@@ -143,6 +141,8 @@ module OSLResources
         # First one should be latest
         releases[0]
       end
+
+      private
 
       def ifconfig_type
         case new_resource.type


### PR DESCRIPTION
This allows us to reuse it in other cookbooks.

Signed-off-by: Lance Albertson <lance@osuosl.org>
