### PR TITLE
Fix bridge_options template to handle both symbol and string keys

### DIFF
--- a/templates/default/nmstate.yml.erb
+++ b/templates/default/nmstate.yml.erb
@@ -57,13 +57,14 @@ interfaces:
     bridge:
 <% if @bridge_options -%>
       options:
-<% if @bridge_options[:stp] -%>
+<% if @bridge_options['stp'] || @bridge_options[:stp] -%>
+<%   stp_opts = @bridge_options['stp'] || @bridge_options[:stp] -%>
         stp:
-<% @bridge_options[:stp].each do |opt, value| -%>
+<% stp_opts.each do |opt, value| -%>
           <%= opt %>: <%= value %>
 <% end -%>
 <% end -%>
-<% @bridge_options.reject { |k, _| k == :stp }.each do |opt, value| -%>
+<% @bridge_options.reject { |k, _| k.to_s == 'stp' }.each do |opt, value| -%>
         <%= opt %>: <%= value %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Chef passes hash keys as strings in production, but Ruby symbol keys were
used in specs. The template only checked for symbol keys (:stp), causing
the stp hash to be rendered twice -- once correctly under the stp: key and
again as a raw Ruby hash from the reject block.

Fix by checking for both string and symbol keys and using .to_s for the
reject filter. Add br43 test resource using string keys to prevent
regression.

Signed-off-by: Lance Albertson <lance@osuosl.org>
