### PR TITLE
Add osl_sysfs_param resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ The following platforms and versions are tested and supported using [test-kitche
 - [osl_shell_environment](documentation/osl_shell_environment.md)
 - [osl_shell_function](documentation/osl_shell_function.md)
 - [osl_ssh_key](documentation/osl_ssh_key.md)
+- [osl_sysfs_param](documentation/osl_sysfs_param.md)
 - [osl_systemd_unit_drop_in](documentation/osl_systemd_unit_drop_in.md)
+- [osl_test_netns](documentation/osl_test_netns.md)
 
 ## Kitchen Dokken
 
-This cookbook supports dokken testing. Dokken tests fail where they need to create network intefaces. The following
-suites are *expected* to fail when using dokken.
+This cookbook supports dokken testing. Dokken tests fail where they need to create network intefaces or otherwise
+change kernel state that a container does not own. The following suites are *expected* to fail when using dokken.
 
 - osl-fakenic
 - osl-fakenic-delete
@@ -40,6 +42,8 @@ suites are *expected* to fail when using dokken.
 - osl-ifconfig-non-idempotent
 - osl-route
 - osl-route-remove
+- osl-sysfs-param
+- osl-sysfs-param-remove
 
 ## Contributing
 

--- a/documentation/osl_sysfs_param.md
+++ b/documentation/osl_sysfs_param.md
@@ -1,0 +1,129 @@
+# osl_sysfs_param
+
+Sets a runtime kernel parameter exposed through `sysfs` (or any other
+pseudo-filesystem entry, such as one under `/proc`) idempotently, so recipes
+do not have to fall back to `execute` with a raw `echo` redirect.
+
+Use this for parameters that `sysctl` does not cover. Module parameters under
+`/sys/module/<module>/parameters/` are the common case: they are writable at
+runtime but have no `sysctl` key, so the only way to change them on a running
+system is to write the file directly. Pair it with a `/etc/modprobe.d` entry
+when the value also needs to survive a reboot.
+
+## Actions
+
+- `:set`: Writes the value if it differs from what the parameter currently reads (default action)
+
+## Properties
+
+| Property         | Type              | Default       | Required | Description                                                                 |
+|------------------|-------------------|---------------|----------|-----------------------------------------------------------------------------|
+| `param_path`     | String            | Resource Name | yes      | Full path to the sysfs entry to write                                       |
+| `value`          | String, Integer   |               | yes      | Value to write; coerced to a stripped String                                |
+| `ignore_missing` | true, false       | `false`       |          | Skip with a warning instead of failing when `param_path` does not exist     |
+| `persist`        | true, false       | `false`       |          | Also write a systemd-tmpfiles fragment so the value is reapplied at boot    |
+
+## Examples
+
+Set the `nf_conntrack` hash table size on a running host:
+
+```ruby
+osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+  value 524288
+end
+```
+
+Use `param_path` explicitly when a more descriptive resource name is wanted:
+
+```ruby
+osl_sysfs_param 'nf_conntrack hashsize' do
+  param_path '/sys/module/nf_conntrack/parameters/hashsize'
+  value      node['osl-openstack']['conntrack']['hashsize']
+end
+```
+
+Tolerate a parameter that may not be present, for example when the module
+providing it is not loaded on every host in a role:
+
+```ruby
+osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+  value 524288
+  ignore_missing true
+end
+```
+
+Set a value now and have it reapplied at boot via systemd-tmpfiles:
+
+```ruby
+osl_sysfs_param '/sys/kernel/mm/ksm/run' do
+  value 1
+  persist true
+end
+```
+
+## Persistence across reboots
+
+`osl_sysfs_param` on its own only changes the running kernel. Pick the
+persistence mechanism by the kind of entry being written:
+
+- Module parameters (`/sys/module/<mod>/parameters/*`): use an
+  `/etc/modprobe.d/<mod>.conf` `options` line alongside this resource, as
+  `osl-openstack::compute` does for `nf_conntrack`. Do not use `persist` for
+  these; see the caveat below.
+- `/proc/sys/*`: use Chef's `sysctl` resource instead of this one. It applies
+  the value at runtime and writes `/etc/sysctl.d` in one step.
+- Everything else (`/sys/kernel/mm/*`, `/sys/block/*/queue/*`, and similar):
+  set `persist true`. The resource writes a one-line fragment to
+  `/etc/tmpfiles.d/chef-<param-path>.conf` and `systemd-tmpfiles-setup`
+  reapplies the value at every boot.
+
+Caveats of `persist`:
+
+- `systemd-tmpfiles-setup.service` runs once, early in boot. A `w` line is
+  silently skipped when its path does not exist yet (same semantics as
+  `ignore_missing`), so `persist` only works for entries present at that
+  point: built-in kernel tunables and devices enumerated before it runs.
+- A module loaded later in boot gets its sysfs parameters after tmpfiles has
+  already run, so nothing is applied. This holds even for modules listed in
+  `/etc/modules-load.d`: systemd-tmpfiles-setup is not ordered after
+  systemd-modules-load, so there is no guarantee the parameter path exists
+  when the fragment is processed. Module parameters belong in
+  `/etc/modprobe.d`, which kmod evaluates at load time wherever that happens.
+  The `kernel_module` resource's `options` property manages exactly that file
+  and its default `:install` action persists the module load itself; pair it
+  with this resource as `osl-openstack::compute` does, or see the
+  `osl_sysfs_param` kitchen suite for a complete reboot-tested example.
+- For attributes of hotplug devices, use a udev rule (see
+  [osl_udev_rules](osl_udev_rules.md)) so the write fires when the device
+  appears. systemd path units are not an option here; sysfs does not generate
+  the inotify events they rely on.
+- `persist false` (the default) deletes the fragment this resource would have
+  created, so turning `persist` off later cleans up after itself.
+- The fragment is only read at boot. During a Chef run the resource itself
+  applies the runtime value, so `systemd-tmpfiles --create` is not invoked.
+
+## Notes
+
+- The current value is compared with trailing whitespace stripped from both
+  sides, so parameters that read back without a trailing newline still
+  converge exactly once.
+- The read and write go through native Ruby `File` methods in
+  `libraries/helpers.rb` rather than a `file` resource. sysfs entries are not
+  regular files, and the `file` provider's content staging, backup and atomic
+  rename steps do not work reliably against them. The write is wrapped in
+  `converge_by`, so why-run and the updated-resource count still report
+  correctly.
+- By default a missing `param_path` raises `Chef::Exceptions::FileNotFound`
+  with a message pointing at the likely cause, which is the providing module
+  not being loaded. Set `ignore_missing true` to downgrade that to a warning.
+- There is no delete or reset action. sysfs entries cannot be removed, and the
+  kernel does not expose a parameter's boot-time default, so there is nothing
+  to reset to. Reboot the host or reload the module to get defaults back.
+- Some parameters normalize what they report, for example returning `Y` for a
+  boolean written as `1`, or bracketing the active choice like
+  `/sys/kernel/mm/transparent_hugepage/defrag` returning `always [defer] ...`.
+  Those converge on every run. Pass the value in the form the parameter reads
+  back where possible to keep the resource idempotent.
+- This only changes the running kernel unless `persist` is set. See
+  "Persistence across reboots" above for choosing between `persist`,
+  `/etc/modprobe.d`, and the `sysctl` resource.

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -215,6 +215,15 @@ suites:
     provisioner:
       enforce_idempotency: false
       multiple_converge: 1
+  - name: osl_sysfs_param
+    run_list:
+      - recipe[osl-resources-test::osl_sysfs_param]
+  - name: osl_sysfs_param_remove
+    run_list:
+      - recipe[osl-resources-test::osl_sysfs_param_remove]
+    provisioner:
+      enforce_idempotency: false
+      multiple_converge: 1
   - name: osl_systemd_unit_drop_in
     run_list:
       - recipe[osl-resources-test::osl_systemd_unit_drop_in]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -453,7 +453,7 @@ module OSLResources
         ::File.exist?(repo_file)
       end
 
-      # osl_test_netns helpers — wrap `ip` lookups so the resource can use
+      # osl_test_netns helpers. Wrap `ip` lookups so the resource can use
       # Ruby `not_if`/`only_if` blocks instead of shelling out from a string.
 
       def osl_netns_exists?(name)
@@ -469,7 +469,7 @@ module OSLResources
       end
 
       # True when the interface's admin flag is UP (operational state may
-      # still be LOWERLAYERDOWN if the peer isn't up yet — that's fine for
+      # still be LOWERLAYERDOWN if the peer isn't up yet, which is fine for
       # idempotency, since `ip link set X up` is a no-op when already admin-up).
       def osl_netns_link_admin_up?(iface, netns: nil)
         out = osl_netns_link_show(iface, netns: netns)
@@ -513,6 +513,41 @@ module OSLResources
         cmd = Mixlib::ShellOut.new(*args)
         cmd.run_command
         cmd.exitstatus.zero? ? cmd.stdout : nil
+      end
+
+      # osl_sysfs_param helpers. sysfs entries are not regular files, so the
+      # file resource's content staging, backup and atomic rename machinery
+      # does not work against them. Read and write them with native Ruby file
+      # methods instead.
+
+      def osl_sysfs_param_read(path)
+        ::File.read(path).strip
+      end
+
+      # Compares stripped values so a parameter that reads back without a
+      # trailing newline still converges exactly once.
+      def osl_sysfs_param_has_value?(path, value)
+        osl_sysfs_param_read(path) == value.to_s.strip
+      end
+
+      # A trailing newline matches what writing the parameter with echo would
+      # produce, which is what the kernel's parameter parsers expect.
+      def osl_sysfs_param_write(path, value)
+        ::File.write(path, "#{value}\n")
+      end
+
+      # Deterministic per-parameter fragment path, so `persist false` can
+      # clean up the same file `persist true` created.
+      def osl_sysfs_param_tmpfiles_path(path)
+        "/etc/tmpfiles.d/chef-#{path.delete_prefix('/').tr('/', '-')}.conf"
+      end
+
+      # A tmpfiles.d `w` line: write the argument to the path at boot, if the
+      # path exists then. The argument field is subject to %-specifier
+      # expansion and C-style backslash escapes, so escape both.
+      def osl_sysfs_param_tmpfiles_line(path, value)
+        escaped = value.to_s.gsub('\\') { '\\\\' }.gsub('%', '%%')
+        "w #{path} - - - - #{escaped}\n"
       end
     end
   end

--- a/resources/osl_sysfs_param.rb
+++ b/resources/osl_sysfs_param.rb
@@ -1,0 +1,48 @@
+resource_name :osl_sysfs_param
+provides :osl_sysfs_param
+unified_mode true
+
+default_action :set
+
+property :param_path, String, name_property: true
+property :value, [String, Integer], required: true, coerce: proc { |v| v.to_s.strip }
+property :ignore_missing, [true, false], default: false
+property :persist, [true, false], default: false
+
+action :set do
+  path = new_resource.param_path
+  desired = new_resource.value
+
+  if ::File.exist?(path)
+    if osl_sysfs_param_has_value?(path, desired)
+      Chef::Log.debug("osl_sysfs_param: #{path} is already set to #{desired}")
+    else
+      converge_by("set sysfs parameter #{path} from #{osl_sysfs_param_read(path)} to #{desired}") do
+        osl_sysfs_param_write(path, desired)
+      end
+    end
+  elsif new_resource.ignore_missing
+    Chef::Log.warn("osl_sysfs_param: #{path} does not exist, skipping")
+  else
+    raise Chef::Exceptions::FileNotFound,
+      "osl_sysfs_param: #{path} does not exist; the module or subsystem providing it may not be loaded"
+  end
+
+  # Reapply the value at boot via a systemd-tmpfiles fragment. A tmpfiles
+  # `w` line writes only when the target exists (verified: silent skip,
+  # exit 0), so this is safe to lay down even for a parameter guarded by
+  # ignore_missing that is absent right now. Managed after the block above
+  # so a raise on a missing parameter does not leave boot config behind.
+  # `persist false` removes the fragment this resource would have created,
+  # so toggling it off cleans up after itself.
+  if new_resource.persist
+    file osl_sysfs_param_tmpfiles_path(path) do
+      content osl_sysfs_param_tmpfiles_line(path, desired)
+      mode '0644'
+    end
+  else
+    file osl_sysfs_param_tmpfiles_path(path) do
+      action :delete
+    end
+  end
+end

--- a/spec/unit/resources/osl_sysfs_param_spec.rb
+++ b/spec/unit/resources/osl_sysfs_param_spec.rb
@@ -1,0 +1,184 @@
+require_relative '../../spec_helper'
+
+describe 'osl_sysfs_param' do
+  platform 'almalinux'
+  step_into :osl_sysfs_param
+
+  let(:param_path) { '/sys/module/nf_conntrack/parameters/hashsize' }
+  let(:tmpfiles_path) { '/etc/tmpfiles.d/chef-sys-module-nf_conntrack-parameters-hashsize.conf' }
+  let(:param_exists) { true }
+  let(:current_content) { "16384\n" }
+
+  before do
+    allow(::File).to receive(:exist?).and_call_original
+    allow(::File).to receive(:exist?).with(param_path).and_return(param_exists)
+    allow(::File).to receive(:read).and_call_original
+    allow(::File).to receive(:read).with(param_path).and_return(current_content)
+    allow(::File).to receive(:write).and_call_original
+    allow(::File).to receive(:write).with(param_path, anything).and_return(nil)
+  end
+
+  context 'current value differs' do
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value 32768
+      end
+    end
+
+    it { is_expected.to set_osl_sysfs_param('/sys/module/nf_conntrack/parameters/hashsize').with(value: '32768') }
+
+    it 'writes the desired value with a trailing newline' do
+      chef_run
+      expect(::File).to have_received(:write).with(param_path, "32768\n")
+    end
+
+    it 'removes the tmpfiles fragment when persist is not set' do
+      expect(chef_run).to delete_file(tmpfiles_path)
+    end
+  end
+
+  context 'persist true' do
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value 32768
+        persist true
+      end
+    end
+
+    it do
+      is_expected.to create_file(tmpfiles_path).with(
+        content: "w /sys/module/nf_conntrack/parameters/hashsize - - - - 32768\n",
+        mode: '0644'
+      )
+    end
+  end
+
+  context 'persist true with a value needing tmpfiles escaping' do
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value '50%'
+        persist true
+      end
+    end
+
+    it 'escapes the percent sign against specifier expansion' do
+      expect(chef_run).to create_file(tmpfiles_path).with(
+        content: "w /sys/module/nf_conntrack/parameters/hashsize - - - - 50%%\n"
+      )
+    end
+  end
+
+  context 'persist true when the parameter is missing and ignore_missing is set' do
+    let(:param_exists) { false }
+
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value 32768
+        ignore_missing true
+        persist true
+      end
+    end
+
+    it { expect { chef_run }.to_not raise_error }
+
+    it 'still lays down the fragment since tmpfiles w lines skip missing paths' do
+      expect(chef_run).to create_file(tmpfiles_path)
+    end
+  end
+
+  context 'current value already matches' do
+    let(:current_content) { "32768\n" }
+
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value 32768
+      end
+    end
+
+    it 'does not write the parameter' do
+      chef_run
+      expect(::File).to_not have_received(:write).with(param_path, anything)
+    end
+  end
+
+  context 'parameter reads back without a trailing newline' do
+    let(:current_content) { '32768' }
+
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value 32768
+      end
+    end
+
+    it 'does not write the parameter' do
+      chef_run
+      expect(::File).to_not have_received(:write).with(param_path, anything)
+    end
+  end
+
+  context 'value given as a String' do
+    let(:current_content) { "32768\n" }
+
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value '32768'
+      end
+    end
+
+    it 'does not write the parameter' do
+      chef_run
+      expect(::File).to_not have_received(:write).with(param_path, anything)
+    end
+  end
+
+  context 'param_path given as a property instead of the resource name' do
+    recipe do
+      osl_sysfs_param 'nf_conntrack hashsize' do
+        param_path '/sys/module/nf_conntrack/parameters/hashsize'
+        value 32768
+      end
+    end
+
+    it { is_expected.to set_osl_sysfs_param('nf_conntrack hashsize').with(param_path: param_path) }
+
+    it 'writes to param_path' do
+      chef_run
+      expect(::File).to have_received(:write).with(param_path, "32768\n")
+    end
+  end
+
+  context 'parameter does not exist' do
+    let(:param_exists) { false }
+
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value 32768
+      end
+    end
+
+    it do
+      expect { chef_run }.to raise_error(
+        Chef::Exceptions::FileNotFound,
+        %r{/sys/module/nf_conntrack/parameters/hashsize does not exist}
+      )
+    end
+  end
+
+  context 'parameter does not exist and ignore_missing is set' do
+    let(:param_exists) { false }
+
+    recipe do
+      osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+        value 32768
+        ignore_missing true
+      end
+    end
+
+    it { expect { chef_run }.to_not raise_error }
+
+    it 'does not write the parameter' do
+      chef_run
+      expect(::File).to_not have_received(:write).with(param_path, anything)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/osl-resources-test/recipes/osl_sysfs_param.rb
+++ b/test/fixtures/cookbooks/osl-resources-test/recipes/osl_sysfs_param.rb
@@ -1,0 +1,53 @@
+# nf_conntrack exposes real, writable module parameters in sysfs and is also
+# the production use case for this resource, so exercise it directly.
+#
+# Load the module now and at every boot (modules-load.d), with its parameters
+# persisted the canonical way for module params: a modprobe.d options file,
+# applied whenever the module loads. The osl_sysfs_param resources below
+# cover the running kernel, so a converge takes effect without a reboot or a
+# module reload. Do not use persist on module parameters; systemd-tmpfiles
+# runs once early in boot and is not ordered after systemd-modules-load, so
+# a fragment pointing into /sys/module cannot be relied on. This suite must
+# verify green after a reboot, which proves the persistence story end to end.
+kernel_module 'nf_conntrack' do
+  options [
+    'hashsize=32768',
+    'acct=1',
+    'tstamp=1',
+  ]
+end
+
+# Integer value, path as the resource name. The kernel rounds hashsize up to
+# a multiple of PAGE_SIZE / 8. 32768 is a multiple of that on both 4K and
+# 64K page kernels, so the value reads back exactly as written and the
+# second converge is a no-op.
+osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+  value 32768
+end
+
+# Boolean module parameter with normalized readback: the kernel reports Y or
+# N regardless of the spelling written, so pass the value in readback form to
+# stay idempotent.
+osl_sysfs_param '/sys/module/nf_conntrack/parameters/acct' do
+  value 'Y'
+end
+
+# Descriptive resource name with the path given via param_path.
+osl_sysfs_param 'nf_conntrack timestamping' do
+  param_path '/sys/module/nf_conntrack/parameters/tstamp'
+  value 'Y'
+end
+
+# A non-module sysfs tunable: ksm is built into the kernel, so its sysfs
+# entries exist before systemd-tmpfiles-setup runs at boot. This is the kind
+# of entry persist is for.
+osl_sysfs_param '/sys/kernel/mm/ksm/run' do
+  value 1
+  persist true
+end
+
+# A parameter that does not exist is skipped rather than failing the run.
+osl_sysfs_param '/sys/module/nf_conntrack/parameters/no_such_param' do
+  value 1
+  ignore_missing true
+end

--- a/test/fixtures/cookbooks/osl-resources-test/recipes/osl_sysfs_param_remove.rb
+++ b/test/fixtures/cookbooks/osl-resources-test/recipes/osl_sysfs_param_remove.rb
@@ -1,0 +1,15 @@
+kernel_module 'nf_conntrack' do
+  action :load
+end
+
+# Simulate a fragment left behind by an earlier run with persist true.
+file '/etc/tmpfiles.d/chef-sys-module-nf_conntrack-parameters-hashsize.conf' do
+  content "w /sys/module/nf_conntrack/parameters/hashsize - - - - 32768\n"
+  mode '0644'
+end
+
+# persist defaults to false, which must clean up the stale fragment while
+# still applying the runtime value.
+osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+  value 32768
+end

--- a/test/integration/osl_sysfs_param/controls/osl_sysfs_param.rb
+++ b/test/integration/osl_sysfs_param/controls/osl_sysfs_param.rb
@@ -1,0 +1,87 @@
+# This control must pass immediately after a converge AND after a reboot of
+# the converged node. Reboot survival comes from three mechanisms working
+# together: modules-load.d loads nf_conntrack at boot, the modprobe.d options
+# file sets its parameters at load time, and the tmpfiles fragment rewrites
+# the built-in ksm tunable.
+control 'osl_sysfs_param' do
+  describe kernel_module('nf_conntrack') do
+    it { should be_loaded }
+  end
+
+  # Boot persistence plumbing laid down by the fixture's kernel_module.
+  describe file('/etc/modules-load.d/nf_conntrack.conf') do
+    it { should exist }
+  end
+
+  describe file('/etc/modprobe.d/options_nf_conntrack.conf') do
+    its('content') { should eq "options nf_conntrack hashsize=32768 acct=1 tstamp=1\n" }
+  end
+
+  # The load-bearing assertions: each runtime parameter actually holds the
+  # value the resource was asked to set.
+  describe command('cat /sys/module/nf_conntrack/parameters/hashsize') do
+    its('exit_status') { should eq 0 }
+    its('stdout.strip') { should cmp 32768 }
+  end
+
+  # Boolean parameter written in the kernel's normalized readback form.
+  describe command('cat /sys/module/nf_conntrack/parameters/acct') do
+    its('exit_status') { should eq 0 }
+    its('stdout.strip') { should eq 'Y' }
+  end
+
+  # Set through param_path with a descriptive resource name.
+  describe command('cat /sys/module/nf_conntrack/parameters/tstamp') do
+    its('exit_status') { should eq 0 }
+    its('stdout.strip') { should eq 'Y' }
+  end
+
+  # Non-module sysfs tunable, persisted via tmpfiles.
+  describe command('cat /sys/kernel/mm/ksm/run') do
+    its('exit_status') { should eq 0 }
+    its('stdout.strip') { should cmp 1 }
+  end
+
+  # ignore_missing must skip the parameter, not create a regular file in its
+  # place.
+  describe file('/sys/module/nf_conntrack/parameters/no_such_param') do
+    it { should_not exist }
+  end
+
+  # persist true lays down a tmpfiles fragment to reapply the value at boot.
+  describe file('/etc/tmpfiles.d/chef-sys-kernel-mm-ksm-run.conf') do
+    it { should exist }
+    its('content') { should eq "w /sys/kernel/mm/ksm/run - - - - 1\n" }
+  end
+
+  # The fragment must parse and reapply cleanly, and the value must survive
+  # the reapplication. Kept as separate commands: the verifier's sudo
+  # prefixes only the first command of a chained string, so anything after
+  # && would run unprivileged.
+  describe command('systemd-tmpfiles --create /etc/tmpfiles.d/chef-sys-kernel-mm-ksm-run.conf') do
+    its('exit_status') { should eq 0 }
+  end
+
+  describe command('cat /sys/kernel/mm/ksm/run') do
+    its('stdout.strip') { should cmp 1 }
+  end
+
+  # persist defaults to false: no fragments for the unpersisted parameters.
+  # Module parameters get no fragment at all; their boot story is the
+  # modprobe.d options file above.
+  describe file('/etc/tmpfiles.d/chef-sys-module-nf_conntrack-parameters-hashsize.conf') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/tmpfiles.d/chef-sys-module-nf_conntrack-parameters-acct.conf') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/tmpfiles.d/chef-sys-module-nf_conntrack-parameters-tstamp.conf') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/tmpfiles.d/chef-sys-module-nf_conntrack-parameters-no_such_param.conf') do
+    it { should_not exist }
+  end
+end

--- a/test/integration/osl_sysfs_param/inspec.yml
+++ b/test/integration/osl_sysfs_param/inspec.yml
@@ -1,0 +1,1 @@
+name: osl_sysfs_param

--- a/test/integration/osl_sysfs_param_remove/controls/osl_sysfs_param_remove.rb
+++ b/test/integration/osl_sysfs_param_remove/controls/osl_sysfs_param_remove.rb
@@ -1,0 +1,12 @@
+control 'osl_sysfs_param_remove' do
+  # The runtime value must still be applied.
+  describe command('cat /sys/module/nf_conntrack/parameters/hashsize') do
+    its('exit_status') { should eq 0 }
+    its('stdout.strip') { should cmp 32768 }
+  end
+
+  # The stale fragment seeded before the resource ran must be gone.
+  describe file('/etc/tmpfiles.d/chef-sys-module-nf_conntrack-parameters-hashsize.conf') do
+    it { should_not exist }
+  end
+end

--- a/test/integration/osl_sysfs_param_remove/inspec.yml
+++ b/test/integration/osl_sysfs_param_remove/inspec.yml
@@ -1,0 +1,1 @@
+name: osl_sysfs_param_remove


### PR DESCRIPTION
## Summary

- Adds `osl_sysfs_param`, which sets runtime kernel parameters exposed through sysfs idempotently, replacing raw execute-with-echo patterns
- Reads and writes go through native Ruby `File` helpers wrapped in `converge_by`; the `file` resource's staging and atomic rename machinery does not work against sysfs entries
- `ignore_missing` skips parameters that are not present (missing paths raise `Chef::Exceptions::FileNotFound` by default)
- `persist` manages a per-parameter systemd-tmpfiles fragment to reapply built-in tunables at boot; `persist false` cleans the fragment back up
- Documentation includes a persistence decision guide: modprobe.d for module parameters, the `sysctl` resource for `/proc/sys`, `persist` for built-in tunables, udev rules for hotplug device attributes

## Test plan

- 15 ChefSpec examples covering value change, no-op, missing-newline readback, String and Integer values, `param_path`, raise on missing, `ignore_missing`, fragment creation, tmpfiles escaping, and fragment cleanup
- `osl_sysfs_param` kitchen suite exercises nf_conntrack module parameters (integer, normalized boolean readback, `param_path`) and the built-in ksm tunable with `persist`, with all six platforms surveyed beforehand to confirm the parameters behave identically
- The suite verifies green immediately after converge and again after a reboot of the converged node, proving the full persistence story (modules-load.d + modprobe.d options + tmpfiles fragment)
- `osl_sysfs_param_remove` suite covers stale fragment cleanup
- No `metadata.rb`/`CHANGELOG.md` changes; Jenkins handles the version bump

First consumer: `osl-openstack::compute` nf_conntrack hashsize tuning, which pairs this resource with a modprobe.d options file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)