### PR TITLE
Document that osl_chrony_server must peer over one address family

### DIFF
--- a/documentation/osl_chrony_server.md
+++ b/documentation/osl_chrony_server.md
@@ -22,7 +22,7 @@ encrypted data bag — never an attribute or a committed value.
 | `enable_nts_server` | `true`/`false` | `false`                     | no       | Serve NTS-KE; only ever takes effect on an off-site server        |
 | `key`               | String         |                             | yes      | The shared symmetric key (hex), from an encrypted data bag        |
 | `key_id`            | Integer        | `1`                         | no       | Key number used in the keyfile and peer lines                     |
-| `ntp_servers`       | Hash           |                             | yes      | Every address of every server, keyed by hostname; a node peers with every address except its own entry |
+| `ntp_servers`       | Hash           |                             | yes      | One address per server, keyed by hostname; a node peers with every address except its own entry. Use a single address family — see below |
 | `nts_server_cert`   | String         |                             | no       | `ntsservercert` path, rendered only when NTS is active            |
 | `nts_server_key`    | String         |                             | no       | `ntsserverkey` path, rendered only when NTS is active             |
 | `pools`             | Hash           | `2.pool.ntp.org`            | no       | `pool` directives (`name => options`)                             |
@@ -37,14 +37,28 @@ node stays inert (no NTS directives). Open the firewall separately with
 ```ruby
 osl_chrony_server 'default' do
   ntp_servers(
-    'ns1' => %w(140.211.166.140 2605:bc80:3010::140),
-    'ns2' => %w(140.211.166.141 2605:bc80:3010::141),
-    'ns3' => %w(216.165.191.54 2600:3402:600:24::154)
+    'ns1' => %w(140.211.166.140),
+    'ns2' => %w(140.211.166.141),
+    'ns3' => %w(216.165.191.54)
   )
   allowed_networks osl_managed_ipv4 + osl_managed_ipv6
   key data_bag_item('chrony', 'keys')['key']
 end
 ```
+
+## Peer over one address family only
+
+List a single address per server in `ntp_servers`. Giving a server two
+addresses opens two peer associations between each pair, which defeats NTP's
+loop detection: a server normally refuses a source whose reference ID points
+back at itself, but an IPv6 source's reference ID is a hash rather than an
+address, so it never matches that peer's own IPv4 address. Two servers can
+then select each other as their clock source and ratchet their stratum upward
+until they hit 16 and go unsynchronised.
+
+Every address of a server still answers clients, because chronyd binds to all
+of them — this constraint is only about which addresses appear in `peer`
+lines.
 
 ## Verification
 

--- a/test/fixtures/cookbooks/osl-resources-test/recipes/osl_chrony_server.rb
+++ b/test/fixtures/cookbooks/osl-resources-test/recipes/osl_chrony_server.rb
@@ -2,9 +2,9 @@
 # a peer. The key is a throwaway test value.
 osl_chrony_server 'default' do
   ntp_servers(
-    'ns1' => %w(192.0.2.10 2001:db8::10),
-    'ns2' => %w(192.0.2.11 2001:db8::11),
-    'ns3' => %w(198.51.100.10 2001:db8:1::10)
+    'ns1' => %w(192.0.2.10),
+    'ns2' => %w(192.0.2.11),
+    'ns3' => %w(198.51.100.10)
   )
   allowed_networks %w(192.0.2.0/24 2001:db8::/32)
   key '746573746b6579746573746b6579746573746b65'

--- a/test/integration/osl_chrony_server/controls/osl_chrony_server.rb
+++ b/test/integration/osl_chrony_server/controls/osl_chrony_server.rb
@@ -11,11 +11,8 @@ control 'osl_chrony_server' do
       # the kitchen host is not in the ntp_servers map, so every address
       # renders as a peer
       /^peer 192.0.2.10 key 1$/,
-      /^peer 2001:db8::10 key 1$/,
       /^peer 192.0.2.11 key 1$/,
-      /^peer 2001:db8::11 key 1$/,
       /^peer 198.51.100.10 key 1$/,
-      /^peer 2001:db8:1::10 key 1$/,
       %r{^allow 192.0.2.0/24$},
       %r{^allow 2001:db8::/32$},
       %r{^keyfile /etc/chrony.keys$},


### PR DESCRIPTION
Follow-up to a production issue found on ns1/ns2 after osuosl-cookbooks/osl-nodes#227 deployed.

## What happened

`osl-nodes::ntp` passed both the v4 and v6 address of each server in `ntp_servers`, so every pair of servers opened **two** peer associations. That defeats NTP's loop detection: a server refuses a source whose reference ID points back at itself, but an IPv6 source's reference ID is a hash rather than an address, so it never matches that peer's own IPv4 address.

The result in production: ns1 selected ns2 as its clock source over IPv4 while ns2 selected ns1 over IPv6, and their stratum ratcheted upward on every update — observed climbing 3/4 → 5/4 → 7/8, heading for 16 (unsynchronised), at which point clients reject them. ns3, which was syncing externally, stayed correctly at stratum 2.

Reference IDs confirming the loop:

| server | refid | resolves to |
|---|---|---|
| ns1 | `8CD3A68D` | `140.211.166.141` (ns2, IPv4) |
| ns2 | `FFBDF59A` | not an address — IPv6 hash for ns1 |
| ns3 | `0BB40D2E` | IPv6 hash for its external stratum-1 source |

## Changes

Documentation only — no resource behavior change, since the address list is supplied by the caller:

- New "Peer over one address family only" section explaining the failure mode
- `ntp_servers` property description and the example updated to one address per server
- Kitchen fixture and its InSpec control updated to match, so the test suite stops demonstrating the pattern that caused this

Note that every address of a server still answers clients — chronyd binds to all of them. This constraint is only about which addresses appear in `peer` lines.

The corresponding production fix is in osuosl-cookbooks/osl-nodes.

## Testing

- `cinc exec cookstyle` clean
- `cinc exec rspec` — 74 chrony examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)